### PR TITLE
Use bool filter for flags

### DIFF
--- a/templates/broker.configmap.yaml
+++ b/templates/broker.configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   broker-config: |
     registry:
-{% if broker_dockerhub_enabled %}
+{% if broker_dockerhub_enabled | bool %}
       - type: dockerhub
         name: {{ broker_dockerhub_name }}
         url: {{ broker_dockerhub_url }}
@@ -21,7 +21,7 @@ data:
           - {{ item | quote }}
 {%     endfor %}
 {% endif  %}
-{% if broker_local_openshift_enabled %}
+{% if broker_local_openshift_enabled | bool %}
       - type: local_openshift
         name: {{ broker_local_openshift_name }}
         namespaces:
@@ -33,7 +33,7 @@ data:
           - {{ item | quote }}
 {%     endfor %}
 {% endif  %}
-{% if broker_helm_enabled %}
+{% if broker_helm_enabled | bool %}
       - type: helm
         name: {{ broker_helm_name }}
         url: {{ broker_helm_url }}

--- a/templates/broker.deployment.yaml
+++ b/templates/broker.deployment.yaml
@@ -44,7 +44,7 @@ spec:
             mountPath: /etc/{{ broker_name }}
           - name: {{ broker_name }}-tls
             mountPath: /etc/tls/private
-{% if broker_basic_auth_enabled %}
+{% if broker_basic_auth_enabled | bool %}
           - name: {{ broker_name }}-auth-volume
             mountPath: /var/run/asb-auth
 {% endif %}
@@ -80,7 +80,7 @@ spec:
         - name: {{ broker_name }}-tls
           secret:
             secretName: {{ broker_name }}-tls
-{% if broker_basic_auth_enabled %}
+{% if broker_basic_auth_enabled | bool %}
         - name: {{ broker_name }}-auth-volume
           secret:
             secretName: {{ broker_name }}-auth-secret


### PR DESCRIPTION
This makes it so that you can:

```
 kubectl run automation-broker-apb -n ansible-service-broker \
--image=docker.io/djzager/automation-broker-apb:latest \
--restart=Never --attach=true \
--serviceaccount=apb \
    -- provision \
        -e 'broker_namespace=ansible-service-broker' \
        -e 'broker_helm_enabled=false'
```

and the helm registry adapter will not be added to the config :sunglasses: 